### PR TITLE
feat: Add ItemList and EducationalOrganization schemas to index pages

### DIFF
--- a/src/components/seo/ProductListSEO.astro
+++ b/src/components/seo/ProductListSEO.astro
@@ -1,0 +1,90 @@
+---
+/**
+ * ProductListSEO Component
+ *
+ * ItemList schema for product listing pages
+ * Helps Google understand the collection of products and their organization
+ *
+ * @component
+ */
+
+import { getCollection } from 'astro:content';
+
+const products = await getCollection('products');
+
+// Construir ItemList Schema
+const itemListSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'ItemList',
+  itemListElement: products.map((product, index) => ({
+    '@type': 'ListItem',
+    position: index + 1,
+    item: {
+      '@type': 'Product',
+      name: product.data.title,
+      description: product.data.description,
+      url: `https://todoconta.com/producto/${product.slug}`,
+      ...(product.data.heroImage && { image: product.data.heroImage }),
+      ...(product.data.category && {
+        category: product.data.category === 'excel'
+          ? 'Plantillas Excel'
+          : product.data.category === 'software'
+          ? 'Software Contable'
+          : 'Servicios Digitales',
+      }),
+      // Agregar oferta si tiene precio único
+      ...(product.data.price && {
+        offers: {
+          '@type': 'Offer',
+          priceCurrency: 'MXN',
+          price: product.data.price,
+        },
+      }),
+      // Agregar AggregateOffer si tiene múltiples planes
+      ...(product.data.plans && product.data.plans.length > 0 && {
+        offers: {
+          '@type': 'AggregateOffer',
+          priceCurrency: 'MXN',
+          lowPrice: Math.min(...product.data.plans.map(p => p.price)),
+          highPrice: Math.max(...product.data.plans.map(p => p.price)),
+          offerCount: product.data.plans.length,
+        },
+      }),
+    },
+  })),
+};
+
+// BreadcrumbList Schema
+const breadcrumbSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    {
+      '@type': 'ListItem',
+      position: 1,
+      name: 'Inicio',
+      item: 'https://todoconta.com',
+    },
+    {
+      '@type': 'ListItem',
+      position: 2,
+      name: 'Productos',
+      item: 'https://todoconta.com/productos',
+    },
+  ],
+};
+---
+
+<!-- ItemList Schema -->
+<script
+  is:inline
+  type="application/ld+json"
+  set:html={JSON.stringify(itemListSchema)}
+/>
+
+<!-- BreadcrumbList Schema -->
+<script
+  is:inline
+  type="application/ld+json"
+  set:html={JSON.stringify(breadcrumbSchema)}
+/>

--- a/src/components/seo/WorkshopsSEO.astro
+++ b/src/components/seo/WorkshopsSEO.astro
@@ -1,0 +1,125 @@
+---
+/**
+ * WorkshopsSEO Component
+ *
+ * SEO schemas for workshops/training page:
+ * - EducationalOrganization schema
+ * - ItemList schema for workshop categories
+ * - Course schema for individual workshops
+ *
+ * @component
+ */
+
+export interface WorkshopCategory {
+  titulo: string;
+  descripcion: string;
+  talleres: string[];
+}
+
+export interface Props {
+  categories: WorkshopCategory[];
+}
+
+const { categories } = Astro.props;
+
+// EducationalOrganization Schema
+const educationalOrgSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'EducationalOrganization',
+  name: 'TodoConta - Capacitación Fiscal y Contable',
+  description:
+    'Institución especializada en capacitación y actualización profesional en temas fiscales y contables para contadores y empresas en México.',
+  url: 'https://todoconta.com/talleres',
+  address: {
+    '@type': 'PostalAddress',
+    addressCountry: 'MX',
+    addressRegion: 'Guerrero',
+  },
+  contactPoint: {
+    '@type': 'ContactPoint',
+    telephone: '+52-1-554-475-3602',
+    contactType: 'customer service',
+    email: 'talleres@todoconta.com',
+    areaServed: 'MX',
+    availableLanguage: 'Spanish',
+  },
+  hasOfferCatalog: {
+    '@type': 'OfferCatalog',
+    name: 'Catálogo de Talleres y Capacitaciones',
+    itemListElement: categories.map(category => ({
+      '@type': 'OfferCatalog',
+      name: category.titulo,
+      itemListElement: category.talleres.map(taller => ({
+        '@type': 'Offer',
+        itemOffered: {
+          '@type': 'Course',
+          name: taller,
+          provider: {
+            '@type': 'EducationalOrganization',
+            name: 'TodoConta',
+          },
+          educationalLevel: 'Professional Development',
+          inLanguage: 'es-MX',
+        },
+      })),
+    })),
+  },
+};
+
+// ItemList Schema para categorías de talleres
+const categoryListSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'ItemList',
+  name: 'Categorías de Talleres Fiscales y Contables',
+  itemListElement: categories.map((category, index) => ({
+    '@type': 'ListItem',
+    position: index + 1,
+    item: {
+      '@type': 'Thing',
+      name: category.titulo,
+      description: category.descripcion,
+    },
+  })),
+};
+
+// BreadcrumbList Schema
+const breadcrumbSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    {
+      '@type': 'ListItem',
+      position: 1,
+      name: 'Inicio',
+      item: 'https://todoconta.com',
+    },
+    {
+      '@type': 'ListItem',
+      position: 2,
+      name: 'Talleres',
+      item: 'https://todoconta.com/talleres',
+    },
+  ],
+};
+---
+
+<!-- EducationalOrganization Schema -->
+<script
+  is:inline
+  type="application/ld+json"
+  set:html={JSON.stringify(educationalOrgSchema)}
+/>
+
+<!-- Category ItemList Schema -->
+<script
+  is:inline
+  type="application/ld+json"
+  set:html={JSON.stringify(categoryListSchema)}
+/>
+
+<!-- BreadcrumbList Schema -->
+<script
+  is:inline
+  type="application/ld+json"
+  set:html={JSON.stringify(breadcrumbSchema)}
+/>

--- a/src/pages/productos/index.astro
+++ b/src/pages/productos/index.astro
@@ -3,6 +3,7 @@ import Layout from '@/layouts/Layout.astro';
 import Navbar from '@/components/layout/Navbar.astro';
 import Products from '@/components/sections/Products.astro';
 import MinimalFooter from '@/components/layout/MinimalFooter.astro';
+import ProductListSEO from '@/components/seo/ProductListSEO.astro';
 
 const cta = {
   title: 'Necesito ayuda',
@@ -14,6 +15,8 @@ const cta = {
   title="Todoconta - Productos de Software Contable"
   description="Descubre nuestras soluciones de software para contadores y empresas. Optimiza la gestión de nóminas y la descarga de XML desde el SAT."
 >
+  <ProductListSEO slot="head" />
+
   <Navbar cta={cta} />
   <Products />
   <MinimalFooter />

--- a/src/pages/talleres/index.astro
+++ b/src/pages/talleres/index.astro
@@ -1,6 +1,7 @@
 ---
 import Layout from '@/layouts/Layout.astro';
 import Button from '@/components/ui/Button.astro';
+import WorkshopsSEO from '@/components/seo/WorkshopsSEO.astro';
 
 // Datos estáticos de categorías de talleres (para mostrar incluso si el iframe no carga)
 const categoriasTalleres = [
@@ -54,6 +55,8 @@ const lumaProfileUrl = 'https://lu.ma/todoconta';
   title="Talleres y Capacitación | Todoconta"
   description="Calendario de talleres y capacitaciones especializadas en temas fiscales y contables. Cursos presenciales y virtuales con enfoque práctico para la optimización fiscal de tu empresa."
 >
+  <WorkshopsSEO slot="head" categories={categoriasTalleres} />
+
   <!-- Hero Section -->
   <section class="talleres-hero">
     <div class="container">


### PR DESCRIPTION
Created two new SEO components for listing pages:

1. ProductListSEO.astro (/productos)
   - ItemList schema with all products from collection
   - Each product includes name, description, image, category
   - Automatic price handling (single price or AggregateOffer for plans)
   - BreadcrumbList schema for navigation

2. WorkshopsSEO.astro (/talleres)
   - EducationalOrganization schema for TodoConta training division
   - hasOfferCatalog with 4 workshop categories
   - Course schema for each individual workshop
   - ItemList schema for workshop categories
   - BreadcrumbList schema for navigation

Benefits:
- Better visibility in Google Shopping (products)
- Rich results for educational content (workshops)
- Improved crawlability of product/course collections
- Enhanced breadcrumb display in search results

Integrated into:
- /productos (5 products with pricing)
- /talleres (16 workshops across 4 categories)

🤖 Generated with [Claude Code](https://claude.com/claude-code)