### PR TITLE
feat: Add Open Graph image for social media preview on Reto 12 Días page

### DIFF
--- a/src/pages/ia-contadores/reto-12-dias/index.astro
+++ b/src/pages/ia-contadores/reto-12-dias/index.astro
@@ -40,6 +40,7 @@ const INSTRUCTOR_NAME = 'Israel Castro';
   title={title}
   description={description}
   keywords={keywords}
+  ogImage="https://s3.us-east-1.amazonaws.com/todoconta.com/uploads/images/reto_ia_contadores_todoconta_2026.jpeg"
   showFooter={false}
 >
   <IARetoSchema


### PR DESCRIPTION
- Add ogImage prop to LandingLayout with S3 hosted image
- Image URL: https://s3.us-east-1.amazonaws.com/todoconta.com/uploads/images/reto_ia_contadores_todoconta_2026.jpeg
- Enables rich previews on WhatsApp, Facebook, LinkedIn, and search engines

This image will be displayed when the page is shared on social media platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)