### PR TITLE
feat: add Google AdSense verification meta tag

### DIFF
--- a/src/layouts/LandingLayout.astro
+++ b/src/layouts/LandingLayout.astro
@@ -60,6 +60,9 @@ const {
     <meta name="twitter:description" content={description} />
     <meta name="twitter:image" content={new URL(ogImage, Astro.url)} />
 
+    <!-- Google AdSense -->
+    <meta name="google-adsense-account" content="ca-pub-7144863238088863" />
+
     <!-- Google Analytics -->
     <script
       async


### PR DESCRIPTION
Add google-adsense-account meta tag to LandingLayout for site ownership verification. Uses meta tag instead of external script for better performance.